### PR TITLE
Block more sites

### DIFF
--- a/GHHbD_perma_ban_list.txt
+++ b/GHHbD_perma_ban_list.txt
@@ -286,6 +286,7 @@ codejzy.com
 codenong.com
 coder.work
 codercto.com
+codertw.com
 codycn.com
 com.sinoextruder.net.cn
 compozi.com
@@ -313,6 +314,7 @@ dc120.com.cn
 ddhyl.cn
 ddoca.com
 deal4investments.com
+debugcn.com
 desertstreams-surprise.com
 dflag.pw
 dgbx888.com
@@ -409,6 +411,7 @@ gdcmendhar.com
 geek-share.com
 geiso.cn
 geistlich-key2success.com
+getit01.com
 getool.com
 gfsoso.zj005.com
 gfsousou.cn
@@ -429,6 +432,7 @@ gsmxm.com
 gufen138.com
 guilinshouji.com
 guiyangjia.com
+gushiciku.cn
 gxy995.com
 gz-has.com
 gzdxdjk.com
@@ -506,9 +510,13 @@ insitedesigns.net
 intowuzhen.com
 iolstl.com
 ironbuffalocomics.com
+it-swarm.cn
 it1352.com
 itdaan.com
+iter01.com
 itranslater.com
+itread01.com
+itw01.com
 iuham.com
 iyangzhi.com
 izlax.cn
@@ -551,6 +559,7 @@ jzxfz.com
 k3m8dr.cn
 kabaresta.com
 kaicen.cn
+kaifa99.com
 kaitianqi.com
 kanduanxin.com
 kaoyu.org

--- a/uBlacklist_subscription.txt
+++ b/uBlacklist_subscription.txt
@@ -286,6 +286,7 @@
 *://*.codenong.com/*
 *://*.coder.work/*
 *://*.codercto.com/*
+*://*.codertw.com/*
 *://*.codycn.com/*
 *://*.com.sinoextruder.net.cn/*
 *://*.compozi.com/*
@@ -313,6 +314,7 @@
 *://*.ddhyl.cn/*
 *://*.ddoca.com/*
 *://*.deal4investments.com/*
+*://*.debugcn.com/*
 *://*.desertstreams-surprise.com/*
 *://*.dflag.pw/*
 *://*.dgbx888.com/*
@@ -409,6 +411,7 @@
 *://*.geek-share.com/*
 *://*.geiso.cn/*
 *://*.geistlich-key2success.com/*
+*://*.getit01.com/*
 *://*.getool.com/*
 *://*.gfsoso.zj005.com/*
 *://*.gfsousou.cn/*
@@ -429,6 +432,7 @@
 *://*.gufen138.com/*
 *://*.guilinshouji.com/*
 *://*.guiyangjia.com/*
+*://*.gushiciku.cn/*
 *://*.gxy995.com/*
 *://*.gz-has.com/*
 *://*.gzdxdjk.com/*
@@ -506,9 +510,13 @@
 *://*.intowuzhen.com/*
 *://*.iolstl.com/*
 *://*.ironbuffalocomics.com/*
+*://*.it-swarm.cn/*
 *://*.it1352.com/*
 *://*.itdaan.com/*
+*://*.iter01.com/*
 *://*.itranslater.com/*
+*://*.itread01.com/*
+*://*.itw01.com/*
 *://*.iuham.com/*
 *://*.iyangzhi.com/*
 *://*.izlax.cn/*
@@ -551,6 +559,7 @@
 *://*.k3m8dr.cn/*
 *://*.kabaresta.com/*
 *://*.kaicen.cn/*
+*://*.kaifa99.com/*
 *://*.kaitianqi.com/*
 *://*.kanduanxin.com/*
 *://*.kaoyu.org/*


### PR DESCRIPTION
* Add sites with lots of pirated articles. Below are example articles:
  (a space is added to the URL to avoid automatic links)

Pirated: https://codertw. com/%e7%a8%8b%e5%bc%8f%e8%aa%9e%e8%a8%80/761795/
Original: https://juejin.cn/post/6931563785245163534

Pirated: https://iter01. com/591791.html
Original: https://learnku.com/articles/55530

Pirated: https://www.itread01. com/ixfeyx.html
Original: https://www.sohu.com/a/332901367_161795

Pirated: https://itw01. com/FGYLEKJ.html
Original: https://developer.aliyun. com/article/205045 （似乎亦為盜版，來自 http://stor-age.zhiding.cn/stor-age/2016/0807/3081509.shtml ）

* Add sites with machine-translated contents from Stack Exchange sites

Translated: https://www.it-swarm. cn/zh/pulseaudio/耳机插孔不工作？/959831380/
Original: https://askubuntu.com/questions/132440/headphone-jack-not-working

Translated: https://kb.kaifa99. com/java/post_935675 (redirected from https://kb.kutu66.com/java/post_935675)
Original: https://stackoverflow.com/questions/9876290/how-do-i-compute-derivative-using-numpy

Translated: https://www.debugcn. com/article/43005056.html
Original: https://stackoverflow.com/questions/54062699/lilypond-change-color-of-notes-below-and-above-a-certain-pitch

* getit01.com: see https://www.zhihu.com/question/266278252 for
discussions

* gushiciku.cn: the previous added content farm. For example,
  https://www.mdeditor. tw/pl/psax is redirected to
  https://www.gushiciku. cn/pl/psax