### PR TITLE
屏蔽《小X百科网》的各种分身网站

### DIFF
--- a/uBlacklist_subscription.txt
+++ b/uBlacklist_subscription.txt
@@ -1198,3 +1198,4 @@
 *://*.zzhesheng.com/*
 *://*.zzjwcf.com/*
 *://cloud.tencent.com/developer/information/*
+title/.* - 小.百科网/


### PR DESCRIPTION
通过网页标题，屏蔽《小X百科网》的各种分身站点（距观察应该不少于10个不同域名，并且会不定时增加），

比如小帽百科网，小匠百科网，小闽百科网等等多个采集站。