### PR TITLE
删除 GHHbD 不支持的 URL

### DIFF
--- a/GHHbD_perma_ban_list.txt
+++ b/GHHbD_perma_ban_list.txt
@@ -1791,8 +1791,3 @@ zzyyo.com
 23.95.222.127
 39.108.60.68
 47.241.89.120
-cloud.tencent.com/developer/ask
-cloud.tencent.com/developer/information
-support.huaweicloud.com/topic
-www.cnpython.com/qa
-www.huaweicloud.com/theme


### PR DESCRIPTION
实测 GHHBD 脚本只能按域名屏蔽，不支持 URL，要么域名整个屏蔽掉（其实屏蔽掉也没什么哈哈），要么就只能再为这些域名维护一个 Block 列表了。
![image](https://user-images.githubusercontent.com/60032845/153977913-4dea26bc-9606-4d3d-9d68-cccbfc843f45.png)