### PR TITLE
Remove herokuapp.com

### DIFF
--- a/GHHbD_perma_ban_list.txt
+++ b/GHHbD_perma_ban_list.txt
@@ -703,7 +703,6 @@ heciao.com.tw
 hedo188.com
 help315.com.cn
 henankuai328.bid
-herokuapp.com
 herpesoutbreaktreatment-reviews.com
 hezu6pro.cn
 hfiphone.com

--- a/uBlacklist_subscription.txt
+++ b/uBlacklist_subscription.txt
@@ -703,7 +703,6 @@
 *://*.hedo188.com/*
 *://*.help315.com.cn/*
 *://*.henankuai328.bid/*
-*://*.herokuapp.com/*
 *://*.herpesoutbreaktreatment-reviews.com/*
 *://*.hezu6pro.cn/*
 *://*.hfiphone.com/*


### PR DESCRIPTION
`herokuapp.com` is the domain provided by the hosting service [Heroku](https://www.heroku.com/). There are many legit apps using this domain. This commit removes `herokuapp.com` from the blocklist to avoid blocking normal websites.