### PR TITLE
Remove npmmirror.com from uBlacklist

### DIFF
--- a/uBlacklist_subscription.txt
+++ b/uBlacklist_subscription.txt
@@ -1650,7 +1650,6 @@
 *://*.noticiarmoz.com/*
 *://*.notwiki.cn/*
 *://*.novascotiascott.com/*
-*://*.npmmirror.com/*
 *://*.nrgmmu.net/*
 *://*.ntustsg.com/*
 *://*.nuomiphp.com/*


### PR DESCRIPTION
淘宝的npm镜像站